### PR TITLE
build: add Jacoco plugin and configuration for code coverage report g…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,11 +70,20 @@ project(":android") {
 
 project(":core") {
     apply plugin: "java-library"
-
+    apply plugin: "jacoco"
 
     dependencies {
         api "com.badlogicgames.gdx:gdx:$gdxVersion"
         
+    }
+    jacoco {
+        toolVersion = "0.8.7" 
+    }
+
+    jacocoTestReport {
+        reports {
+            html.destination file("${buildDir}/reports/jacocoHtml")
+        }
     }
 }
 


### PR DESCRIPTION
Using the commando:
```cmd
gradlew jacocoTestReport 
```
One can now generate test coverage reports
![image](https://github.com/SverreNystad/besieged/assets/89105607/948c9654-24c9-4fd9-be39-3961a35c849a)
